### PR TITLE
9D Radeline -74f ish

### DIFF
--- a/9D_02_Peaceful_Solitude.tas
+++ b/9D_02_Peaceful_Solitude.tas
@@ -39,7 +39,7 @@ console load nameguysdsidespack/0/10-Farewell 8678 -1184
    1,R,J,G
    5,R
    3,R,J
-   5,R
+   4,R
    8,R,J
   10,L,D,X
    5,R,J
@@ -97,21 +97,21 @@ console load nameguysdsidespack/0/10-Farewell 8678 -1184
    3,R
   15,R,X
    2,R
-  15,L,J
+  14,L,J
   15,U,X
    1
   39,L,U,J,G
   12,R,K,G
-   5,R,G
+   4,R,G
   16,R,K
-  50,L,J
+  49,L,J
  160
    3
    4,D,X
-  10,L,X
+   9,L,X
    1,R,J
    7,R,D
-   8,R
+   7,R
   15,D,X
    7,R,D
   24,L,D

--- a/9D_03_Glimpse_of_Freedom.tas
+++ b/9D_03_Glimpse_of_Freedom.tas
@@ -71,7 +71,7 @@ console load nameguysdsidespack/0/10-Farewell 8804 -1940
    5,R,D,J
    8,J
    9,U,X
-  33,R,U,G
+  32,R,U,G
    1,R,D
   14,R,J
    4,D,X
@@ -130,7 +130,7 @@ console load nameguysdsidespack/0/10-Farewell 8804 -1940
    4,R
   13,L,J
   14,U,X
-   5,R,C
+   4,R,C
   14,R,X
  105,R,U,G
    1,L
@@ -169,11 +169,11 @@ console load nameguysdsidespack/0/10-Farewell 8804 -1940
    7,R,J
   15,R,D,X
   14,R,D,C
-  26,R,D,G
+  25,R,D,G
    1,R
    9,L,D,X
   14,R,U,C
-  60,R,U,G
+  58,R,U,G
    1,R
   15,D,X
   15,R,U,C
@@ -373,7 +373,7 @@ console load nameguysdsidespack/0/10-Farewell 8804 -1940
    2,R,K,G
    7,R
    4,K
-   4,R,K
+   3,R,K
    4,D,X
    6,R,X
    1,R,K
@@ -471,8 +471,8 @@ console load nameguysdsidespack/0/10-Farewell 8804 -1940
   12,R,D,G
    6,R
   12,R,U,X
-  10,U,C
-  37,R,G
+   9,U,C
+  36,R,G
    1,L
   29,R
    4,D,X
@@ -560,8 +560,6 @@ console load nameguysdsidespack/0/10-Farewell 8804 -1940
   21,L
    2,L,G
    5,L,D,G
-   1,L,G
-   1,L,D,G
  140,L,G
    1,K
   13,L,J,G

--- a/9D_04_Curiosity.tas
+++ b/9D_04_Curiosity.tas
@@ -34,9 +34,9 @@ console givekey
   12,L,D,X
    1,L,J
    4,L,K,G
-   7,G
-  16,D,X
-   7,D
+   6,G
+  15,D,X
+   8,D
    7,L,D
   10,R,D,X
   26,R,J

--- a/9D_06_Memories.tas
+++ b/9D_06_Memories.tas
@@ -184,7 +184,6 @@ console load nameguysdsidespack/0/10-Farewell 36709 -4968
   24,R,C
    4,D,X
   12,R,U,X
-   1
   28,R,D,C
   14,R,X
   20,R,D
@@ -244,7 +243,7 @@ console load nameguysdsidespack/0/10-Farewell 36709 -4968
   13,R,D
   15,D,X
    5,R,D
-   7,L,D
+   6,L,D
    1
   14,R,D,X
    1,R,J
@@ -254,7 +253,7 @@ console load nameguysdsidespack/0/10-Farewell 36709 -4968
    3,R
    4,D,C
   11,R,C
-  14,R,X
+  13,R,X
    4,D,C
   24,R,C
    4,D,X
@@ -400,7 +399,7 @@ console load nameguysdsidespack/0/10-Farewell 36709 -4968
    5,R,K
    2,R
   21,L,U,G
-   6,G
+   5,G
    1,R,J
   15,R,D,X
    1,R,D
@@ -516,7 +515,7 @@ console load nameguysdsidespack/0/10-Farewell 36709 -4968
   80,G
   10,D,G
   30,G
-  30,R,G
+  29,R,G
   20,G
   34,R,U,X
   70,G

--- a/9D_07_Creation.tas
+++ b/9D_07_Creation.tas
@@ -383,7 +383,7 @@ console givekey
    3,J
   12,R,K,G
   13,J,G
-  10,R,K,G
+   9,R,K,G
    5,L,J
   15,R,U,X
   19,R,D

--- a/9D_08_Exploration.tas
+++ b/9D_08_Exploration.tas
@@ -31,7 +31,7 @@ console load nameguysdsidespack/0/10-Farewell e-05 1
   27,R,D,X
    4,R,J
    7,R,K
-   5,R
+   4,R
    4,R,J
    5,R
    4,X
@@ -409,7 +409,7 @@ console load nameguysdsidespack/0/10-Farewell e-05 1
    2,J,G
 #Section f-09
    4,D,X
-   2,R,X
+   1,R,X
    1,R,J
    7,R
    1,R,J
@@ -702,7 +702,7 @@ console load nameguysdsidespack/0/10-Farewell e-05 1
    1,J
    3
    1,K,G
-   7,R
+   6,R
    6,L,X
    4,D,C
    2,R,C

--- a/9D_09_Depression.tas
+++ b/9D_09_Depression.tas
@@ -315,7 +315,7 @@ console load nameguysdsidespack/0/10-Farewell f-99 1
    8,R,J
    4,R
    4,D,X
-   4,L,X
+   3,L,X
    1,R,J
    5,R
   40

--- a/9D_10_Trust.tas
+++ b/9D_10_Trust.tas
@@ -124,7 +124,7 @@ console load nameguysdsidespack/0/10-Farewell h-08
    2,R
    1
   19,R
-  19,R,J
+  18,R,J
   15,U,X
    6,R,J
    1,R,K,G

--- a/9D_11_Serenity.tas
+++ b/9D_11_Serenity.tas
@@ -317,7 +317,7 @@ console load nameguysdsidespack/0/10-Farewell hh-08 1
   27,L,G
    3,K,G
    2,R,K
-  11,R,J
+  10,R,J
   27,R,G
    6,J,G
    1,L,J

--- a/9D_12_Revisit.tas
+++ b/9D_12_Revisit.tas
@@ -265,7 +265,7 @@ console load nameguysdsidespack/0/10-Farewell j-00
   14,R,U,X
   39,R
   10,R,X
-  39,L
+  38,L
    4,D,X
   12,L,U,X
   57,R
@@ -277,7 +277,7 @@ console load nameguysdsidespack/0/10-Farewell j-00
   15,R,U,C
    6,R
   37
-   7,R
+   5,R
    9,R,U,X
   36,L
   15,L,U,X
@@ -673,7 +673,7 @@ console load nameguysdsidespack/0/10-Farewell j-00
    1,L,K,G
   23,L,J,G
   23,L,U,X
-  41
+  40
    1,R,J
    4,R,K
   33,R,U,X

--- a/9D_13A_1000M.tas
+++ b/9D_13A_1000M.tas
@@ -56,7 +56,7 @@ console givekey
   22,R,U,X
    4,R,J
    4,R,K
-   6,K
+   5,K
    4,D,X
    9,L,U,X
    8,L,J
@@ -204,7 +204,7 @@ console givekey
    8,R
    2,J
   12,R,J
-   4,R,K,G
+   3,R,K,G
   18,R,X
   16,D,C
    8,L,D

--- a/9D_13B_1500M.tas
+++ b/9D_13B_1500M.tas
@@ -700,7 +700,7 @@ console load nameguysdsidespack/0/10-Farewell 114405 -19248
    1,R,K,G
    5,L,K
   10,L
-  33,L,G
+  32,L,G
    1,L,J,G
    1,L,K,G
   14,L,J,G

--- a/9D_14A_2000M.tas
+++ b/9D_14A_2000M.tas
@@ -183,10 +183,10 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
    3,F,90
   21,F,83
    7,F,70
-  11,F,53
+  10,F,53
   28,F,355
   10,F,345
-   4,L
+   3,L
    4,D,X
    6,L,X
    5,L,J
@@ -207,10 +207,10 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
 
    1,R
    1,J
-   7,R,J
-   8,K,G
+   6,R,J
+   7,K,G
    1,L,J
-  33,L,K
+  32,L,K
   15,U,X
   21,L,J
    4,K,G
@@ -421,7 +421,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
 
 
   26
-  13,F,72
+  12,F,72
   37,F,60
   10,F,
   12,F,300
@@ -481,7 +481,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
    5
    8,R
    5
-   5,R
+   4,R
    5,L,D,X
    5,L,X
    1,U
@@ -549,7 +549,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
   13,L,G
   12,J,G
   10,K,G
-  12,J
+  11,J
   15,U,X
    2,R,J
    7,J
@@ -600,7 +600,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
 
   28,R,D
   15,R,U,X
-  20,R,D
+  19,R,D
   16,R
 
   14,R,U,C
@@ -1027,7 +1027,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
   11,R,X
   17,L
    3,L,J,G
-   9,L
+   8,L
   17
    1,U
    4,D,X
@@ -1083,7 +1083,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
   12,D
    9,L
    2
-  14,R,D,X
+  13,R,D,X
   10,R,J
    1,R
    6,R,J
@@ -1104,8 +1104,9 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
    7
 
    1,L,J
-  17,L,K
-  28,R,J
+  15,L,K
+   2,R,K
+  27,R,J
   14,U,X
   18,L,J
   12,K,G
@@ -1145,7 +1146,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
   27
   15,U,X
   16,U,C
-  12,J,G
+  11,J,G
    8,G
    9,L,J,G
   10,L

--- a/9D_14A_2000M.tas
+++ b/9D_14A_2000M.tas
@@ -1146,7 +1146,7 @@ console load nameguysdsidespack/0/10-Farewell 120956 -22700
   27
   15,U,X
   16,U,C
-  11,J,G
+  12,J,G
    8,G
    9,L,J,G
   10,L

--- a/9D_14B_2500M.tas
+++ b/9D_14B_2500M.tas
@@ -223,7 +223,7 @@ console load nameguysdsidespack/0/10-Farewell o-01outside
 
 #lvl_c-06
   14,R,D
-  23,R,D,X
+  22,R,D,X
   15,L,D,C
   24,R,X
   10,U,C
@@ -360,7 +360,7 @@ console load nameguysdsidespack/0/10-Farewell o-01outside
   14,L,D,C
    1,R,J
   15,D,C
-   8
+   7
    4,D,X
   10,L,X
    1,R,J
@@ -430,7 +430,7 @@ console load nameguysdsidespack/0/10-Farewell o-01outside
   17,R,D
    7,L,D
    4,D,X
-  19,L,X
+  18,L,X
   21,R,D
   20,L,X
    9,L,U,C
@@ -586,7 +586,7 @@ lvl_o-10s
    1,R,J
 
    8,R,D
-   8,D
+   7,D
   15,R,U,X
   14,D
   23,U,X
@@ -725,7 +725,7 @@ lvl_o-10s
   14,L
    1,L,J
   23,L,D
-   7,L
+   6,L
   19,L,D,J
    2,K
    1,J

--- a/9D_15_Sunrise_Running.tas
+++ b/9D_15_Sunrise_Running.tas
@@ -650,7 +650,7 @@ console load nameguysdsidespack/0/10-Farewell 135764 -35048
   16,R,U,X
    5,R,J,G
   12,R,D,X
-  69,R,C
+  68,R,C
   28,R,D,X
 
 #CP-56

--- a/9D_16_Goodbye_of_the_Mountain.tas
+++ b/9D_16_Goodbye_of_the_Mountain.tas
@@ -1524,7 +1524,7 @@ console load nameguysdsidespack/0/10-Farewell 145652 -39958
    1,L,D,J
    9,L
    3,L,J
-  19,U,X
+  18,U,X
   23,U,C
   23,U,X
   15,R,C
@@ -1537,7 +1537,7 @@ console load nameguysdsidespack/0/10-Farewell 145652 -39958
    1,O
   68
  141
-   6,R,J
+   5,R,J
    4,D,X
   10,R,X
    2,R,J

--- a/9D_17_Heart_Beating.tas
+++ b/9D_17_Heart_Beating.tas
@@ -168,7 +168,7 @@ console load nameguysdsidespack/0/10-Farewell 165051 -45256
   32,U,X
   18,R,C
    4,L,G
-  20,D,X
+  19,D,X
   15,R,D,C
   16,D,X
   10,L,D,C

--- a/9D_20_Plural.tas
+++ b/9D_20_Plural.tas
@@ -63,28 +63,27 @@ console load nameguysdsidespack/0/10-Farewell 188364 -48416
    2,R,K
   14
    1,L,J
-  20,J
+  18,J
    7,R,D,X
-  45,R
+  47,R
   22,R,U,X
-  24,R,D,C
+  22,R,D,C
    4,D,X
-   6,R,X
-   2,R,J
-   4,R,K,G
-   7,R,D,X
+  10,R,X
+   1,R,J
+   6,R,D,X
   40
 
 #lvl_t-04
 #CP-18
-   7,R,D,X
-  11,R,J
-  14,R,U,X
+   8,R,D,X
+  10,R,J
+  15,R,U,X
   42,L
    5,R,C
  135
   17,R,D,X
-  11,R
+  10,R
   24,R,X
   43,L,D
   15,D,X
@@ -501,7 +500,7 @@ console load nameguysdsidespack/0/10-Farewell 188364 -48416
   29,L,D
   15,L,X
   15,L,D
-  26,R
+  24,R
   15,U,X
    5
   18,R,J

--- a/9D_21_True_Love.tas
+++ b/9D_21_True_Love.tas
@@ -249,7 +249,7 @@ console load nameguysdsidespack/0/10-Farewell u-01
   99,R,D
   40
 
-#lvl_u-05
+#lvl_u-06
   25,R,D
    1,D
    1,R,D

--- a/9D_22_Reunification.tas
+++ b/9D_22_Reunification.tas
@@ -706,7 +706,7 @@ console givekey
   15,R,C
    4
    6,R
-  31,R,U,G
+  30,R,U,G
   41,R,D,G
    1,R
   10,L
@@ -926,7 +926,7 @@ console givekey
    1,R,J
   15,R,D,X
   15,R,C
-  12,R,D
+  11,R,D
    1,R,G
   14,R,J
   20,R,X
@@ -971,7 +971,7 @@ console givekey
    1,R,D
    1,R,D
    4,D,X
-  11,R,X
+  10,R,X
    8,L,J
    7,L
    4,D,X

--- a/9D_24_Edge_of_the_Universe.tas
+++ b/9D_24_Edge_of_the_Universe.tas
@@ -127,7 +127,7 @@ console load nameguysdsidespack/0/10-Farewell 222371 -51312
    9,L
    2,R
   14,R,U,X
-  66,R,U,G
+  65,R,U,G
   24,R,D,G
    1,R
    7,L,D

--- a/9D_28_Infinity.tas
+++ b/9D_28_Infinity.tas
@@ -1005,7 +1005,6 @@ console p_twodashes
 #lvl_z-exit
    7,L,D
    3
-   1,L,G
    6,L,J
   19,L,D,X
  227,L,C
@@ -1078,7 +1077,7 @@ console p_twodashes
    1,R,D
    1,R,D
    4,D,X
-  11,R,X
+  10,R,X
    8,L,J
    7,L
    4,D,X


### PR DESCRIPTION
Void of input buffers or other issues, doesn't include the changes after June 1st. Confirmed to sync on both XNA and FNA (except [CPs 16 and *maybe* 9](https://youtu.be/gMDgHPQ0YfI?t=321))

01: 0
02: 6
03: 10
04: 1
05: 0
06: 6
07: 1
08: 3
09: 1
10: 1
11: 1
12: 4
13A: 2
13B: 1
14A: 12
14B: 5
15: 1
16: 2
17-18: 1
19: 0
20: 5
21: 0
22: 3
23: 3
24: 1
25: 0
26: N/A
27: broken
28: 2

Total: 74
(May not be exactly accurate)
(And these [logs](https://github.com/EuniverseCat/celeste_tas/files/4880870/9d.radeline.logs.zip) *definitely* aren't)